### PR TITLE
feat: can no longer scroll off the edge of the map

### DIFF
--- a/docs/js/map.js
+++ b/docs/js/map.js
@@ -13,10 +13,17 @@ const icon = L.icon({
     });
 
 function createMap(id) {
+    let viewCoords = [33.97, -118.365];
+    let maxBounds = L.latLngBounds(
+        L.latLng(34.9815, -117.1395), //northeast map corner
+        L.latLng(33.638, -119.1851) //southwest map corner
+    );
+
     map = L.map(id, {
+        maxBounds: maxBounds,
         maxZoom: 16,
         minZoom: 10
-    }).setView([33.97, -118.365], 11);
+    }).setView(viewCoords, 11);
 
     L.esri.tiledMapLayer({url: rasterBaseMap}).addTo(map);
     layerGroup = L.featureGroup().addTo(map);

--- a/src/js/map.js
+++ b/src/js/map.js
@@ -13,10 +13,17 @@ const icon = L.icon({
     });
 
 function createMap(id) {
+    let viewCoords = [33.97, -118.365];
+    let maxBounds = L.latLngBounds(
+        L.latLng(34.9815, -117.1395), //northeast map corner
+        L.latLng(33.638, -119.1851) //southwest map corner
+    );
+
     map = L.map(id, {
+        maxBounds: maxBounds,
         maxZoom: 16,
         minZoom: 10
-    }).setView([33.97, -118.365], 11);
+    }).setView(viewCoords, 11);
 
     L.esri.tiledMapLayer({url: rasterBaseMap}).addTo(map);
     layerGroup = L.featureGroup().addTo(map);


### PR DESCRIPTION
This adds a boundary at the edge of your map tiles such that when the user attempts to scroll past the available map content, it will instead bounce the user back to the edge of the map. This solves the problem of -- once the user scrolls entirely off the map, they have no way of knowing how to get back to the map without doing a full page reload.

(And of course feel free to ignore this, I'm just a random Metro enthusiast + software dev :) )